### PR TITLE
docs: fix star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ See more documentation at <https://document.saasfly.io>
 
 ## 🌟 Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=saasfly/saasfly&type=Timeline)](https://star-history.com/#saasfly/saasfly&Timeline)
+[![Star History Chart](https://app.repohistory.com/api/svg?repo=saasfly/saasfly&type=Timeline)](https://repohistory.com)
 
 ## Sponsors
 

--- a/README_de.md
+++ b/README_de.md
@@ -31,7 +31,7 @@ Weitere Dokumentation finden Sie unter <https://document.saasfly.io>.
 
 ## 🌟 Stern-Verlauf
 
-[![Star History Chart](https://api.star-history.com/svg?repos=saasfly/saasfly&type=Timeline)](https://star-history.com/#saasfly/saasfly&Timeline)
+[![Star History Chart](https://app.repohistory.com/api/svg?repo=saasfly/saasfly&type=Timeline)](https://repohistory.com)
 
 ## 🚀 Erste Schritte
 

--- a/README_vi.md
+++ b/README_vi.md
@@ -29,7 +29,7 @@ Máy chủ demo 2 (Địa điểm: Tokyo, Nhật Bản): <https://demo.saasfly.i
 
 ## 🌟 Lịch sử Star
 
-[![Biểu đồ lịch sử Star](https://api.star-history.com/svg?repos=saasfly/saasfly&type=Timeline)](https://star-history.com/#saasfly/saasfly&Timeline)
+[![Biểu đồ lịch sử Star](https://app.repohistory.com/api/svg?repo=saasfly/saasfly&type=Timeline)](https://repohistory.com)
 
 ## 🚀 Bắt đầu
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -30,7 +30,7 @@
 
 ## 🌟 Star历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=saasfly/saasfly&type=Timeline)](https://star-history.com/#saasfly/saasfly&Timeline)
+[![Star History Chart](https://app.repohistory.com/api/svg?repo=saasfly/saasfly&type=Timeline)](https://repohistory.com)
 
 ## 赞助商
 


### PR DESCRIPTION
Hi! I'm the maintainer of [Repohistory](https://github.com/repohistory/repohistory). I noticed your star history chart is broken and not displaying properly.

I updated READMEs to use Repohistory's star chart feature which provides reliable rendering in GitHub markdown with the same functionality as star-history.

You can preview here: https://github.com/m4xshen/saasfly

If you don't like current style you can customize the chart by modifying the URL parameters:
  - color=HEXCOLOR - Change chart color (without #)
  - theme=light|dark - Light or dark theme
  - type=Date|Timeline - Date or timeline mode
  - transparent=true|false - Transparent background